### PR TITLE
Backtrace!

### DIFF
--- a/core/ev-admin.php
+++ b/core/ev-admin.php
@@ -191,7 +191,6 @@ class SP_EV_Admin {
       // get the relevant local author from host
       $update_hosts = array( $this_host=>$HOSTS[$this_host] ); // has to stay indexed and loopable
       $update_author = $HOSTS[$this_host]['authors'][$this_author]; // has to be whole author array
-      error_log( print_r( $update_author, true ) );
 
     } else {
 
@@ -233,7 +232,7 @@ class SP_EV_Admin {
   *  @return  array( html $messages, array $new_video_ids )
   */
 
-  function post_new_videos( $update_hosts, $update_author ) {
+  function post_new_videos( $update_hosts, $update_author = null ) {
 
     $new_video_ids = array();
     $new_videos = $this->fetch_new_videos( $update_hosts, $update_author );
@@ -408,7 +407,7 @@ class SP_EV_Admin {
   *  @return  $new_videos (array of videos)
   */
 
-  function fetch_new_videos( $update_hosts, $update_author = null ) {
+  function fetch_new_videos( $update_hosts, $update_author ) {
 
     $new_videos = array();
 

--- a/core/ev-settings-forms.php
+++ b/core/ev-settings-forms.php
@@ -43,7 +43,7 @@ $HOSTS = $options['hosts'];
             <div class="inside big">
               <p>
                 <?php esc_attr_e(
-                  'External Videos allows your WordPress site to connect to your accounts at video hosting sites. For each video it finds on a channel, it creates a new post in WordPress. For example, EV can find all the videos of the user "Fred" on YouTube, and add each of them as a new "external-videos" post.',
+                  'External Videos (EV) allows your WordPress site to connect to your accounts at video hosting sites. For each video it finds on a channel, it creates a new post in WordPress. For example, EV can find all the videos of the user "Fred" on YouTube, and add each of them as a new "external-videos" post.',
                   'external-videos'
                 ); ?>
               </p>

--- a/external-videos.php
+++ b/external-videos.php
@@ -103,12 +103,9 @@ class SP_External_Videos {
     // create a "video" category to store posts against
     wp_create_category(__( 'External Videos', 'external-videos' ) );
 
-    $options = get_option( 'sp_external_videos_options' );
-    if( $options && isset( $options['slug'] ) ){
-      $rewrite = $options['slug'];
-    } else {
-      $rewrite = 'external-videos';
-    }
+    // load the saved options or initialize with default values
+    $options = $this->get_options();
+    // echo '<pre style="margin-left:150px;">$options: '; print_r($options); echo '</pre>';
 
     // create "external videos" post type
     register_post_type( 'external-videos', array(
@@ -124,16 +121,13 @@ class SP_External_Videos {
       'supports'        => array( 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'trackbacks', 'custom-fields', 'comments', 'revisions', 'post-formats' ),
       'taxonomies'      => array( 'post_tag', 'category' ),
       'has_archive'     => true,
-      'rewrite'         => array( 'slug' => $rewrite ),
+      'rewrite'         => array( 'slug' => $options['slug'] ),
       'yarpp_support'   => true
     ));
 
     // enable thickbox use for gallery
     wp_enqueue_style( 'thickbox' );
     wp_enqueue_script( 'thickbox' );
-
-    // move author options to hosts
-    $this->convert_author_options();
 
   }
 
@@ -228,12 +222,9 @@ class SP_External_Videos {
 
     if( "settings_page_external-videos/external-videos" != $hook ) return;
 
-    // wp_enqueue_script( 'jquery-ui-tabs' );
-    // wp_enqueue_script( 'jquery-ui-accordion' );
-
     wp_register_style( 'ev-admin', plugin_dir_url( __FILE__ ) . '/css/ev-admin.css', array(), null, 'all' );
     wp_enqueue_style( 'ev-admin' );
-    wp_register_script( 'ev-admin', plugin_dir_url( __FILE__ ) . '/js/ev-admin.js', array( 'jquery'/*, 'jquery-ui-tabs', 'jquery-ui-accordion' */), false, true );
+    wp_register_script( 'ev-admin', plugin_dir_url( __FILE__ ) . '/js/ev-admin.js', array( 'jquery' ), false, true );
     wp_enqueue_script( 'ev-admin' );
 
     // for the nonce
@@ -250,8 +241,8 @@ class SP_External_Videos {
   /*
   *  get_options
   *
-  *  Used by ev-admin.php, feed_request(), daily_function()
   *  Gets sp_external_videos_options, returns usable array $options
+  *  which is stored into the SP_External_Videos class
   *
   *  @type  function
   *  @date  31/10/16
@@ -263,24 +254,26 @@ class SP_External_Videos {
 
   static function get_options(){
 
-    // Load existing plugin options for this form
-    $raw_options = get_option( 'sp_external_videos_options' );
+    // Load existing plugin options
+    $options = get_option( 'sp_external_videos_options' );
     // echo '<pre>$raw_options: '; print_r($raw_options); echo '</pre>';
 
+    if( !$options ) {
+      $options = array();
+    }
+    // Upgrade options to v1.0: move author options to hosts
+    $options = SP_External_Videos::convert_author_options( $options );
+
     // Set defaults for the basic options
-    if( !$raw_options ) {
-      $options = array( 'version' => 1, 'hosts' => array(), 'rss' => false, 'delete' => true, 'attrib' => false, 'loop' => false );
-    } else {
-      $options = $raw_options;
-      // below is needed, because if anything gets unset it throws an error
-      if( !array_key_exists( 'version', $options ) ) $options['version'] = 1;
-      if( !array_key_exists( 'authors', $options ) ) $options['authors'] = array();
-      if( !array_key_exists( 'hosts', $options ) ) $options['hosts'] = array();
-      if( !array_key_exists( 'rss', $options ) ) $options['rss'] = false;
-      if( !array_key_exists( 'delete', $options ) ) $options['delete'] = false;
-      if( !array_key_exists( 'attrib', $options ) ) $options['attrib'] = false;
-      if( !array_key_exists( 'loop', $options ) ) $options['loop'] = false;
-    };
+    // There are new options that may not be set yet
+    if( !array_key_exists( 'version', $options ) ) $options['version'] = 1;
+    if( !array_key_exists( 'rss', $options ) ) $options['rss'] = false;
+    if( !array_key_exists( 'delete', $options ) ) $options['delete'] = false;
+    if( !array_key_exists( 'hosts', $options ) ) $options['hosts'] = array();
+    if( !array_key_exists( 'attrib', $options ) ) $options['attrib'] = false;
+    if( !array_key_exists( 'loop', $options ) ) $options['loop'] = false;
+    if( !array_key_exists( 'slug', $options ) ) $options['slug'] = 'external-videos';
+
     // echo '<pre style="margin-left:150px;">$options: '; print_r($options); echo '</pre>';
 
     return $options;
@@ -290,6 +283,7 @@ class SP_External_Videos {
   /*
   *  convert_author_options
   *
+  *  This is for an update of the plugin to version 1.0.
   *  Move authors array under respective hosts for much easier indexing.
   *  This is a database conversion function that is light and runs automatically
   *  but is really needed once only. Could be moved to settings-page AJAX
@@ -303,12 +297,10 @@ class SP_External_Videos {
   *  @return
   */
 
-  function convert_author_options(){
+  function convert_author_options( $options ){
 
-    $options = get_option( "sp_external_videos_options" );
-
-    if( !array_key_exists( 'hosts', $options ) ) return;
-    if( !array_key_exists( 'authors', $options ) ) return;
+    if( !array_key_exists( 'hosts', $options ) ) return $options;
+    if( !array_key_exists( 'authors', $options ) ) return $options;
 
     $AUTHORS = $options['authors'];
 
@@ -320,6 +312,8 @@ class SP_External_Videos {
 
     unset( $options['authors'] );
     update_option( 'sp_external_videos_options', $options );
+
+    return $options;
 
   }
 
@@ -379,9 +373,8 @@ class SP_External_Videos {
 
   function add_to_main_query( $query ) {
 
-    $options = SP_External_Videos::get_options();
-
-    if( !isset( $options['loop'] ) || $options['loop'] == false ) return;
+    $options = $this->get_options();
+    if( $options['loop'] == false ) return;
 
     if( is_home() ) {
       $post_type = get_query_var( 'post_type' );
@@ -628,7 +621,7 @@ class SP_External_Videos {
 
   function feed_request( $qv ) {
 
-    $options = SP_External_Videos::get_options();
+    $options = $this->get_options();
 
     if ( $options['rss'] == true ) {
       if ( isset( $qv['feed'] ) && !isset( $qv['post_type'] ) )
@@ -728,4 +721,5 @@ endif;
 
 global $SP_External_Videos;
 $SP_External_Videos = new SP_External_Videos();
+
 ?>

--- a/hosts/ev-dotsub.php
+++ b/hosts/ev-dotsub.php
@@ -185,7 +185,7 @@ class SP_EV_Dotsub {
         $video['description'] = $vid['description'];
         $video['authorname']  = $vid['user'];
         $video['videourl']    = $vid['displayURI'];
-        $video['published']   = date("Y-m-d H:i:s", strtotime($vid['dateCreated']));
+        $video['published']   = gmdate("Y-m-d\TH:i:s\Z", $vid['dateCreated']/1000);
         $video['author_url']  = $vid['externalIdentifier'];
         $video['category']    = '';
         $video['keywords']    = array();

--- a/hosts/ev-vimeo.php
+++ b/hosts/ev-vimeo.php
@@ -219,12 +219,16 @@ class SP_EV_Vimeo {
         $code = wp_remote_retrieve_response_code( $response );
         $message = wp_remote_retrieve_response_message( $response );
         $body = json_decode( wp_remote_retrieve_body( $response ), true ); // true to return array, not object
+
+        // Interpret errors from the API - should really raise this as an exception
+        if ( isset($body['error']) ) {
+          // print_r( $body['error'] );
+          return [];
+        }
+
         // Adjust array to get to the data
         $data = $body['data'];
         $next = $body['paging']['next'];
-        // $page = $body->page;
-        // $per_page = $body->per_page;
-        // $total = $body->total;
       }
       catch ( Exception $e ) {
         echo "Encountered an API error -- code {$e->getCode()} - {$e->getMessage()}";

--- a/hosts/ev-wistia.php
+++ b/hosts/ev-wistia.php
@@ -159,7 +159,6 @@ class SP_EV_Wistia {
     $thumb_w = ( null !== get_option( "thumbnail_size_w" ) ) ? get_option( "thumbnail_size_w" ) : 180;
     $thumb_h = ( null !== get_option( "thumbnail_size_h" ) ) ? get_option( "thumbnail_size_h" ) : 135;
 
-
     $baseurl = "https://api.wistia.com/v1/medias.json?sort_by=created&sort_direction=1&per_page=" . $per_page;
     // part of the url changes on subsequent page requests:
     $url = $baseurl . "&page=" . $page;

--- a/readme.txt
+++ b/readme.txt
@@ -72,12 +72,13 @@ You can add a link like this to your theme layout.
 == Changelog ==
 
 = 1.0 =
-* Major refactor - AJAX admin forms for live plugin settings and video updates
-* All video sites work again, using their current APIs
-* YouTube - Vimeo - Dotsub - Wistia
+* Major refactor - thanks to Andrew Nimmo
+* All video sites updated to their current APIs
+* YouTube - Vimeo - Dotsub - Wistia updated
 * Dailymotion added
+* Settings: Added AJAX admin forms for live plugin settings and video updates
 * New settings option: Add external-videos to main Home page query (latest posts)
-* New settings option: Automatically append attribution (categories, author and hosting site) to external-video post content, or not
+* New settings option: Automatically append attribution (categories, author and hosting site) to external-video post content
 * New admin column to sort external-videos by category
 * Note that some time since WP 3.5, you can no longer access connected external-videos from the Media Uploader, to add them to a post or page (other than the original external-videos post). This is because of hooks inaccessible since WP Media changed to backbone.js; this part of the plugin's functionality could be integrated with the Media Explorer plugin project.
 
@@ -193,3 +194,9 @@ You can add a link like this to your theme layout.
 
 = 0.1 =
 * Initial version
+
+
+== Upgrade Notice ==
+
+= 1.0 =
+Major refactor, now supports YouTube - Vimeo - Dotsub - Wistia - Dailymotion, much better settings page


### PR DESCRIPTION
Silvia - I re-added all your commits one by one, but:

1. `external-videos.php` Simplified the function `get_options` so the defaults are not defined twice.
2. `ev-admin.php` Changed functions relating to updating and deleting videos from authors to fix the persistent trash error with simpler logic. This one change affects four other functions, but i think you will agree it is an improvement. Here is an explanation:

`get_authors()` - removed this redundant function that was confusing the update and delete-videos loops. We don't need a list of all authors for any of the functions -we're always looping authors by host.

The functions
- `update_videos_handler`
- `post_new_videos`
- `trash_deleted_videos`
- `fetch_new_videos`

...now pass these simplified variables: 
- `$update_hosts` (**single host** if we're updating a single author, **all hosts** if updating all)
- `$update_author` (**single author** if we're updating a single author, **null** if updating all)

Most importantly, `trash_deleted_videos` still had a tortuous logic, now simplified:

When fetching the updated array of videos from a single author's hosting service, the function was still looping through an array of **all existing external-videos posts** and comparing with the author's updated array of $new_videos. Anything in $all_existing_videos that was not in the single author's $new_videos was assumed to be "deleted on the host", so it was trashed. 

You wrote a fix to skip to next video if the host was not an $update_hosts, 
```
// next video if we're looking at a video not on a updated site
if ( !in_array( $host, $update_hosts ) ) continue;
```
but if there were **two authors on the same host**, this would still delete the other author's videos during a single author update - they would not be in the single author's $new_videos array, even though the $host was the same. 

It seemed simpler for `trash_deleted_videos` to have two versions of `WP_Query` to compare existing videos on the WP instance with updated videos on the host. 
- If we're updating a single author, it uses a narrower `WP_Query` with a meta query, and only loops the **existing videos of the relevant author** to check against $new_videos. 
- If updating all, it loops all external-videos as before.