### PR TITLE
Update readme to 4.8

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 - Donate link: http://www.gingertech.net/
 - Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 - Requires at least: 4.4
-- Tested up to: 4.7.1
+- Tested up to: 4.8
 - Stable Tag: 1.1
 - License: GPLv2
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -24,7 +24,7 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 
 # Description
 
-This plugin connects WordPress to your video channels on YouTube, Vimeo, DotSub, Wistia, or Dailymotion, and crossposts the videos automatically. For example, it finds all the videos of the user "Fred" on YouTube and adds them each as a new post on WordPress. The posts are created as a separate post type, "external-videos", but can optionally be added to your posts page or news feed like regular posts. Your videos, once imported, can also be added to any other post via the media library, or presented in a gallery using the shortcode [external-videos]. There is also a widget to add a list of the most recent videos in a sidebar.
+This plugin connects WordPress to your video channels on YouTube, Vimeo, DotSub, Wistia, or Dailymotion, and cross-posts the videos in WordPress automatically. For example, it finds all the videos of the user "Fred" on YouTube and adds them each as a new post on WordPress. The posts are created as a separate post type, "external-videos", but can optionally be added to your posts page or news feed like regular posts. Your videos, once imported, can also be added to any other post via the media library, or presented in a gallery using the shortcode [external-videos]. There is also a widget to add a list of the most recent videos in a sidebar.
 
 
 # Installation

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 - Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 - Requires at least: 4.4
 - Tested up to: 4.8
-- Stable Tag: 1.1
+- Stable Tag: 1.1.1
 - License: GPLv2
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: silviapfeiffer1, johnfjohnf, nimmolo
 Donate link: http://www.gingertech.net/
 Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 Requires at least: 4.4
-Tested up to: 4.7
+Tested up to: 4.8
 Stable Tag: 1.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -12,7 +12,7 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 
 == Description ==
 
-This plugin connects WordPress to your video channels on YouTube, Vimeo, DotSub, Wistia, or Dailymotion, and crossposts the videos automatically. For example, it finds all the videos of the user "Fred" on YouTube and adds them each as a new post on WordPress. The posts are created as a separate post type, "external-videos", but can optionally be added to your posts page or news feed like regular posts. Your videos, once imported, can also be added to any other post via the media library, or presented in a gallery using the shortcode [external-videos]. There is also a widget to add a list of the most recent videos in a sidebar.
+This plugin connects WordPress to your video channels on YouTube, Vimeo, DotSub, Wistia, or Dailymotion, and cross-posts the videos in WordPress automatically. For example, it finds all the videos of the user "Fred" on YouTube and adds them each as a new post on WordPress. The posts are created as a separate post type, "external-videos", but can optionally be added to your posts page or news feed like regular posts. Your videos, once imported, can also be added to any other post via the media library, or presented in a gallery using the shortcode [external-videos]. There is also a widget to add a list of the most recent videos in a sidebar.
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.gingertech.net/
 Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 Requires at least: 4.4
 Tested up to: 4.8
-Stable Tag: 1.1
+Stable Tag: 1.1.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
The only things changed should be the readmes - i also added the words "in WordPress" after "crossposts" so it's clear which way they are cross posted (i.e., plugin does not cross post your YouTube videos to Vimeo, for example)