### PR TITLE
PR for 1.2 SVN fix

### DIFF
--- a/external-videos.php
+++ b/external-videos.php
@@ -4,7 +4,7 @@
 * Plugin URI: http://wordpress.org/extend/plugins/external-videos/
 * Description: Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymotion to your WordPress site as new posts.
 * Author: Silvia Pfeiffer and Andrew Nimmo
-* Version: 1.1
+* Version: 1.2
 * Author URI: http://www.gingertech.net/
 * License: GPL2
 * Text Domain: external-videos
@@ -32,7 +32,7 @@
   @author     Silvia Pfeiffer <silviapfeiffer1@gmail.com>, Andrew Nimmo <andrnimm@fastmail.fm>
   @copyright  Copyright 2010+ Silvia Pfeiffer
   @license    http://www.gnu.org/licenses/gpl.txt GPL 2.0
-  @version    1.1
+  @version    1.2
   @link       http://wordpress.org/extend/plugins/external-videos/
 
 */

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,8 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 - Donate link: http://www.gingertech.net/
 - Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 - Requires at least: 4.4
-- Tested up to: 4.8
-- Stable Tag: 1.1.1
+- Tested up to: 4.8.2
+- Stable Tag: 1.2
 - License: GPLv2
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 
 
 # Changelog
+
+### 1.2
+* Massive bug fix! /hosts folder was missing from WP SVN repository.
 
 ### 1.1
 * Media Uploader: External Videos can now be added to any post, like photos or other media items, once they are imported. (Functions rewritten using Media Explorer framework)

--- a/readme.md
+++ b/readme.md
@@ -103,7 +103,7 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 # Changelog
 
 ### 1.2
-* Massive bug fix! /hosts folder was missing from WP SVN repository.
+* Massive bug fix! /hosts folder was missing from WP SVN repository. Thanks to @ianmacin!
 
 ### 1.1
 * Media Uploader: External Videos can now be added to any post, like photos or other media items, once they are imported. (Functions rewritten using Media Explorer framework)

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 == Changelog ==
 
 = 1.2 =
-* Massive bug fix! /hosts folder was missing from WP SVN repository.
+* Massive bug fix! /hosts folder was missing from WP SVN repository. Thanks to @ianmacin!
 
 = 1.1 =
 * Media Uploader: After External Videos are imported, they can now be added to any post, like photos or other media items. (Functions rewritten using Media Explorer framework)

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: silviapfeiffer1, johnfjohnf, nimmolo
 Donate link: http://www.gingertech.net/
 Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 Requires at least: 4.4
-Tested up to: 4.8
-Stable Tag: 1.1.1
+Tested up to: 4.8.2
+Stable Tag: 1.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 7. Media Uploader: inserting External Videos into any page or post
 
 == Changelog ==
+
+= 1.2 =
+* Massive bug fix! /hosts folder was missing from WP SVN repository.
 
 = 1.1 =
 * Media Uploader: After External Videos are imported, they can now be added to any post, like photos or other media items. (Functions rewritten using Media Explorer framework)


### PR DESCRIPTION
Folders and assets are missing from /hosts on SVN, causing the plugin not to load these resources, as pointed out by @ianmacin on the support forum. For SVN, version number must change to force folder upload. This change will effectively (re)introduce Media Explorer features not available in the flawed SVN repo for 1.1, so version bump to 1.2.