### PR TITLE
New option to embed in post content (default) or not

### DIFF
--- a/core/ev-admin.php
+++ b/core/ev-admin.php
@@ -480,13 +480,17 @@ class SP_EV_Admin {
     // get options, to check if user wants the rest of content
     $options = SP_External_Videos::get_options();
 
+    // embed the video at the top if option selected
     if( $options['embed'] == true ) {
       $video_content = "\n";
       $video_content .= esc_url( $video['embed_url'] );
       $video_content .= "\n\n";
-      $video_content .= '<p>' . sanitize_text_field( trim( $video['description'] ) ) . '</p>';
     }
 
+    // add the description no matter what
+    $video_content .= '<p>' . sanitize_text_field( trim( $video['description'] ) ) . '</p>';
+
+    // add the attribution if that option is selected
     if( $options['attrib'] == true ) {
       $video_content .= '<p><small>';
       if ( $video['category'] != '' ) {

--- a/core/ev-admin.php
+++ b/core/ev-admin.php
@@ -139,6 +139,7 @@ class SP_EV_Admin {
 
     $options['rss'] = ( array_key_exists( 'ev-rss', $fields ) ? true : false );
     $options['delete'] = ( array_key_exists( 'ev-delete', $fields ) ? true : false );
+    $options['embed'] = ( array_key_exists( 'ev-embed', $fields ) ? true : false );
     $options['attrib'] = ( array_key_exists( 'ev-attrib', $fields ) ? true : false );
     $options['loop'] = ( array_key_exists( 'ev-loop', $fields ) ? true : false );
     $options['slug'] = ( array_key_exists( 'ev-slug', $fields ) ? sanitize_title_with_dashes( $fields['ev-slug'] ) : '' );
@@ -442,7 +443,7 @@ class SP_EV_Admin {
   /*
   *  save_video
   *
-  *  Used by update_videos() and update_videos_handler()
+  *  Used by post_new_videos() and update_videos_handler()
   *  Creates a post of type "external-videos" and saves it.
   *  The passed $video array contains the fields we need to make the post,
   *  all except "embed_url" (provided by embed_url()).
@@ -472,15 +473,19 @@ class SP_EV_Admin {
         return false;
       }
     }
-
+    // NEW 1.3.1: Make the embed in content optional too
     // put content together
-    $video_content = "\n";
-    $video_content .= esc_url( $video['embed_url'] );
-    $video_content .= "\n\n";
-    $video_content .= '<p>' . sanitize_text_field( trim( $video['description'] ) ) . '</p>';
+    $video_content = "";
 
     // get options, to check if user wants the rest of content
     $options = SP_External_Videos::get_options();
+
+    if( $options['embed'] == true ) {
+      $video_content = "\n";
+      $video_content .= esc_url( $video['embed_url'] );
+      $video_content .= "\n\n";
+      $video_content .= '<p>' . sanitize_text_field( trim( $video['description'] ) ) . '</p>';
+    }
 
     if( $options['attrib'] == true ) {
       $video_content .= '<p><small>';

--- a/core/ev-settings-forms.php
+++ b/core/ev-settings-forms.php
@@ -73,6 +73,7 @@ $HOSTS = $options['hosts'];
               <?php // get saved options
                 $ev_rss = $options['rss'];
                 $ev_del = $options['delete'];
+                $ev_embed = $options['embed'];
                 $ev_attrib = $options['attrib'];
                 $ev_loop = $options['loop'];
                 $ev_slug = $options['slug'];
@@ -81,6 +82,12 @@ $HOSTS = $options['hosts'];
                 <label for="ev-loop">
                   <input type="checkbox" id="ev-loop" name="ev-loop" value="loop" <?php if ( $ev_loop == true ) echo "checked"; ?>/>
                   <span><?php esc_attr_e('Add external-video posts to the Home loop (latest Posts page)', 'external-videos'); ?></span>
+                </label>
+              </fieldset>
+              <fieldset>
+                <label for="ev-embed">
+                  <input type="checkbox" id="ev-embed" name="ev-embed" value="embed" <?php if ( $ev_embed == true ) echo "checked"; ?>/>
+                  <span><?php esc_attr_e('Embed video in video post content? (This is the default. Otherwise, video must be manually added to a template by a developer using post_meta attributes)', 'external-videos'); ?></span>
                 </label>
               </fieldset>
               <fieldset>

--- a/core/ev-settings-forms.php
+++ b/core/ev-settings-forms.php
@@ -87,7 +87,7 @@ $HOSTS = $options['hosts'];
               <fieldset>
                 <label for="ev-embed">
                   <input type="checkbox" id="ev-embed" name="ev-embed" value="embed" <?php if ( $ev_embed == true ) echo "checked"; ?>/>
-                  <span><?php esc_attr_e('Embed video in video post content? (This is the default. Otherwise, video must be manually added to a template by a developer using post_meta attributes)', 'external-videos'); ?></span>
+                  <span><?php esc_attr_e('Embed video in video post content? (This is the default. Otherwise, video can be manually added to template by a developer using `get_post_meta(get_the_ID(), "video_url");`)', 'external-videos'); ?></span>
                 </label>
               </fieldset>
               <fieldset>

--- a/external-videos.php
+++ b/external-videos.php
@@ -4,7 +4,7 @@
 * Plugin URI: http://wordpress.org/extend/plugins/external-videos/
 * Description: Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymotion to your WordPress site as new posts.
 * Author: Silvia Pfeiffer and Andrew Nimmo
-* Version: 1.3.0
+* Version: 1.3.1
 * Author URI: http://www.gingertech.net/
 * License: GPL2
 * Text Domain: external-videos
@@ -32,7 +32,7 @@
   @author     Silvia Pfeiffer <silviapfeiffer1@gmail.com>, Andrew Nimmo <andrnimm@fastmail.fm>
   @copyright  Copyright 2010+ Silvia Pfeiffer
   @license    http://www.gnu.org/licenses/gpl.txt GPL 2.0
-  @version    1.2.1
+  @version    1.3.1
   @link       http://wordpress.org/extend/plugins/external-videos/
 
 */
@@ -248,6 +248,7 @@ class SP_External_Videos {
     if( !array_key_exists( 'rss', $options ) ) $options['rss'] = false;
     if( !array_key_exists( 'delete', $options ) ) $options['delete'] = false;
     if( !array_key_exists( 'hosts', $options ) ) $options['hosts'] = array();
+    if( !array_key_exists( 'embed', $options ) ) $options['embed'] = true;
     if( !array_key_exists( 'attrib', $options ) ) $options['attrib'] = false;
     if( !array_key_exists( 'loop', $options ) ) $options['loop'] = false;
     if( !array_key_exists( 'slug', $options ) ) $options['slug'] = 'external-videos';

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 - Donate link: http://www.gingertech.net/
 - Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 - Requires at least: 4.4
-- Tested up to: 6.2.1
+- Tested up to: 6.2.2
 - Stable Tag: 1.3.1
 - License: GPLv2
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 - Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 - Requires at least: 4.4
 - Tested up to: 6.2.1
-- Stable Tag: 1.3.0
+- Stable Tag: 1.3.1
 - License: GPLv2
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -102,8 +102,11 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 
 # Changelog
 
-### 1.3.0
-* Fix to work with YouTube's evolving API 3.0, which changed and broke the plugin in 2017
+### 1.3.1
+* New option to *not* automatically embed the video in `post_content` when fetching from the service. The video URL is already stored in `post_meta`. This allows developers to manually add the video elsewhere in the template markup.
+
+### 1.3
+* YouTube API changed since EV 1.2, regarding channel/username URLs. This updates EV's username check accordingly. (If your channel was broken or not updating, visit the EV YouTube settings page and inter your YouTube username. EV will pull from your default YouTube "uploads" video channel now. Custom channels are not available.)
 
 ### 1.2.1
 * Bump WP tested-with version to current 6.2.1

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: silviapfeiffer1, johnfjohnf, nimmolo
 Donate link: http://www.gingertech.net/
 Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 Requires at least: 4.4
-Tested up to: 6.2.1
+Tested up to: 6.2.2
 Stable Tag: 1.3.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.gingertech.net/
 Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 Requires at least: 4.4
 Tested up to: 6.2.1
-Stable Tag: 1.3.0
+Stable Tag: 1.3.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -86,8 +86,11 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 
 == Changelog ==
 
+= 1.3.1 =
+* New option to *not* automatically embed the video in `post_content` when fetching from the service. The video URL is already stored in `post_meta`. This allows developers to manually add the video elsewhere in the template markup.
+
 = 1.3.0 =
-* Fix to work with YouTube's evolving API 3.0, which changed and broke the plugin in 2017
+* YouTube API changed since EV 1.2, regarding channel/username URLs. This updates EV's username check accordingly. (If your channel was broken or not updating, visit the EV YouTube settings page and inter your YouTube username. EV will pull from your default YouTube "uploads" video channel now. Custom channels are not available.)
 
 = 1.2.1 =
 * Bump WP tested-with version to current 6.2.1


### PR DESCRIPTION
New option to *not* automatically embed the video in `post_content` when fetching from the service. If embed is **unchecked**, the `post_content` will only contain the video description.

The video URL is already separately stored in `post_meta`. Not embedding it in content allows developers 👋 to manually add the video elsewhere in the template markup.