### PR TITLE
1.3.2 - Remove existing embeds from post_content

### DIFF
--- a/core/ev-settings-forms.php
+++ b/core/ev-settings-forms.php
@@ -87,7 +87,7 @@ $HOSTS = $options['hosts'];
               <fieldset>
                 <label for="ev-embed">
                   <input type="checkbox" id="ev-embed" name="ev-embed" value="embed" <?php if ( $ev_embed == true ) echo "checked"; ?>/>
-                  <span><?php esc_attr_e('Embed video in video post content? (This is the default. Otherwise, video can be manually added to template by a developer using `get_post_meta(get_the_ID(), "video_url");`)', 'external-videos'); ?></span>
+                  <span><?php esc_attr_e('Embed video in external-video post content? (This is the default. Only disable this if you are writing a custom theme.)', 'external-videos'); ?></span>
                 </label>
               </fieldset>
               <fieldset>
@@ -137,7 +137,7 @@ $HOSTS = $options['hosts'];
             <input type="hidden" name="action" value="ev_update_videos" />
             <p class="">
               <input type="submit" name="Submit" class="button" value="<?php esc_attr_e( 'Update videos from all channels', 'external-videos' ); ?>" />
-              <div class="spinner inline"></div>
+              <span class="spinner inline"></span>
             </p>
           </form>
 
@@ -145,6 +145,26 @@ $HOSTS = $options['hosts'];
             <?php /* This is loaded by ajax now. */ ?>
           </form>
           <!-- end of Update Videos -->
+
+          <br class="clear"/>
+
+          <h3><?php esc_attr_e( 'Remove embedded videos from existing external-video post_content', 'external-videos' ); ?></h3>
+          <p>
+            <?php esc_attr_e( 'As of v1.3.1, videos don\'t have to be embedded directly in `post_content`. A developer can code the video to appear elsewhere on the page within a custom template, using something like `get_post_meta(get_the_ID(), "video_url");`.', 'external-videos' ); ?>
+          <p>
+          </p>
+            <?php esc_attr_e( 'Click the button below to remove the embedded videos from all external-video post_content. Please only use this if you know what you\'re doing.' ); ?>
+          </p>
+
+          <form id="ev_unembed_videos" method="post" action="">
+            <div class="feedback"></div>
+            <!-- <input type="hidden" name="external_videos" value="Y" /> -->
+            <input type="hidden" name="action" value="ev_unembed_videos" />
+            <p class="">
+              <input type="submit" name="Submit" class="button" value="<?php esc_attr_e( 'Remove embedded videos from all external-videos post content', 'external-videos' ); ?>" />
+              <span class="spinner inline"></span>
+            </p>
+          </form>
 
           <br class="clear"/>
 
@@ -159,7 +179,7 @@ $HOSTS = $options['hosts'];
             <input type="hidden" name="action" value="ev_delete_videos" />
             <p class="">
               <input type="submit" name="Submit" class="button" value="<?php esc_attr_e('Move all external videos to trash', 'external-videos'); ?>" />
-              <div class="spinner inline"></div>
+              <span class="spinner inline"></span>
             </p>
           </form>
           <!-- end of Delete All Videos -->

--- a/external-videos.php
+++ b/external-videos.php
@@ -4,7 +4,7 @@
 * Plugin URI: http://wordpress.org/extend/plugins/external-videos/
 * Description: Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymotion to your WordPress site as new posts.
 * Author: Silvia Pfeiffer and Andrew Nimmo
-* Version: 1.3.1
+* Version: 1.3.2
 * Author URI: http://www.gingertech.net/
 * License: GPL2
 * Text Domain: external-videos

--- a/hosts/youtube/ev-youtube.php
+++ b/hosts/youtube/ev-youtube.php
@@ -215,6 +215,11 @@ class SP_EV_YouTube {
 
     // error_log( '$body' . print_r( $body, true ) );
     // The first result has the channel.
+    // if( !is_array( $body ) ) {
+    //   error_log( print_r($body, true) );
+    //   return;
+    // }
+
     $channelId = $body["items"][0]["id"];
     $uploadsPlaylistId = $body["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"];
 

--- a/js/ev-admin.js
+++ b/js/ev-admin.js
@@ -14,17 +14,17 @@
  *
 */
 
-(function( $ ) {
+(function ($) {
 
   // SETTINGS TABS
-  var tabChange = function(){
-    $('.nav-tab-wrapper a').click( function() {
+  var tabChange = function () {
+    $('.nav-tab-wrapper a').click(function () {
       $('.nav-tab').removeClass('nav-tab-active');
       $('section').fadeOut();
       var chosen = $('section').eq($(this).index()),
-          choose = function(){ chosen.fadeIn(); },
-          feedback = $("#ev_author_list .feedback");
-      window.setTimeout( choose, 300 );
+        choose = function () { chosen.fadeIn(); },
+        feedback = $("#ev_author_list .feedback");
+      window.setTimeout(choose, 300);
       $(this).addClass('nav-tab-active');
       fadeNotice(feedback);
       return false;
@@ -32,14 +32,14 @@
   };
 
   // EDIT AUTHOR COLLAPSING FORMS
-  var formExpand = function(){
-    $(document).on("click", ".ev-host-table a.edit-author", function(e) {
+  var formExpand = function () {
+    $(document).on("click", ".ev-host-table a.edit-author", function (e) {
       e.preventDefault();
       var table = $(this).parents("table"),
-          save = $(this).siblings("button"),
-          open = $(this).children(".open"),
-          closed = $(this).children(".closed"),
-          panel = $(table).children(".info-author");
+        save = $(this).siblings("button"),
+        open = $(this).children(".open"),
+        closed = $(this).children(".closed"),
+        panel = $(table).children(".info-author");
 
       $(closed).toggle();
       $(open).toggle();
@@ -50,32 +50,32 @@
   };
 
   // fadeCallback for fadeNotice
-  var fadeCallback = function(feedback){
-    $(feedback).children().fadeOut( 1000 );
+  var fadeCallback = function (feedback) {
+    $(feedback).children().fadeOut(1000);
   };
 
   // fadeNotice
-  var fadeNotice = function(feedback){
-    window.setTimeout( function(){
+  var fadeNotice = function (feedback) {
+    window.setTimeout(function () {
       fadeCallback(feedback);
-    }, 8000 );
+    }, 8000);
   };
 
   // Plugin Settings handler
-  var settingsUpdate = function(){
-    $('#ev_plugin_settings').submit(function(e){
+  var settingsUpdate = function () {
+    $('#ev_plugin_settings').submit(function (e) {
 
       e.preventDefault();
       var pluginSettings = $('#ev_plugin_settings').serialize();
 
-      $.post( evSettings.ajax_url, {
+      $.post(evSettings.ajax_url, {
         _ajax_nonce: evSettings.nonce,
         action: "plugin_settings_handler",
         data: pluginSettings,
         dataType: 'json'
-      }, function(data){
+      }, function (data) {
         var message = $(data).prop("message"),
-            slug = $(data).prop("slug");
+          slug = $(data).prop("slug");
         $("#ev_plugin_settings .feedback").html(message);
         $("#ev_plugin_settings input#ev-slug").val(slug);
       });
@@ -83,21 +83,21 @@
   };
 
   // Update Videos handler
-  var updateVideos = function(){
-    $('#ev_update_videos').submit(function(e){
+  var updateVideos = function () {
+    $('#ev_update_videos').submit(function (e) {
 
       e.preventDefault();
 
       var feedback = $("#ev_update_videos .feedback"),
-          spinner = $("#ev_update_videos .spinner");
+        spinner = $("#ev_update_videos .spinner");
 
       $(spinner).addClass("is-active");
 
-      $.post( evSettings.ajax_url, {
+      $.post(evSettings.ajax_url, {
         _ajax_nonce: evSettings.nonce,
         action: "update_videos_handler"
         // data: No data sent,
-      }, function(data){
+      }, function (data) {
         $(spinner).removeClass("is-active");
         $("#ev_update_videos .feedback").html(data);
         $(feedback).html(data);
@@ -106,26 +106,53 @@
     });
   };
 
-  // Delete All handler
-  var deleteAll = function(){
-    $('#ev_delete_all').submit(function(e){
+  // Unembed Videos handler
+  var unembedVideos = function () {
+    $('#ev_unembed_videos').submit(function (e) {
 
       e.preventDefault();
 
-      var feedback = $("#ev_delete_all .feedback"),
-          spinner = $("#ev_delete_all .spinner");
+      var feedback = $("#ev_unembed_videos .feedback"),
+        spinner = $("#ev_unembed_videos .spinner");
 
-      if (!confirm('Are you sure you want to delete all external video posts?')){
+      if (!confirm('This will effectively remove the videos from your site, unless your theme is specifically coded otherwise.')) {
         return false;
       }
       $(spinner).addClass("is-active");
 
-      $.post( evSettings.ajax_url, {
+      $.post(evSettings.ajax_url, {
+        _ajax_nonce: evSettings.nonce,
+        action: "unembed_videos_handler"
+        // data: No data sent,
+      }, function (data) {
+        $(spinner).removeClass("is-active");
+        $("#ev_unembed_videos .feedback").html(data);
+        $(feedback).html(data);
+        fadeNotice(feedback);
+      });
+    });
+  };
+
+  // Delete All handler
+  var deleteAll = function () {
+    $('#ev_delete_all').submit(function (e) {
+
+      e.preventDefault();
+
+      var feedback = $("#ev_delete_all .feedback"),
+        spinner = $("#ev_delete_all .spinner");
+
+      if (!confirm('Are you sure you want to delete all external video posts?')) {
+        return false;
+      }
+      $(spinner).addClass("is-active");
+
+      $.post(evSettings.ajax_url, {
         _ajax_nonce: evSettings.nonce,
         data: '',
         dataType: 'html',
         action: "delete_all_videos_handler"
-      }, function(data){
+      }, function (data) {
         $(spinner).removeClass("is-active");
         $(feedback).html(data);
         fadeNotice(feedback);
@@ -134,26 +161,26 @@
   };
 
   // Check Videos handler
-  var checkVideos = function(){
-    $(document).on("click", "#ev_author_list .button-update", function(e){
+  var checkVideos = function () {
+    $(document).on("click", "#ev_author_list .button-update", function (e) {
 
       e.preventDefault();
       // alert( evSettings.nonce );
 
       var hostId = $(this).attr("data-host"),
-          authorId = $(this).attr("data-author"),
-          spinner = $(this).siblings(".spinner"),
-          feedback = $("#ev_author_list .feedback");
+        authorId = $(this).attr("data-author"),
+        spinner = $(this).siblings(".spinner"),
+        feedback = $("#ev_author_list .feedback");
 
       $(spinner).addClass("is-active");
 
-      $.post( evSettings.ajax_url, {
+      $.post(evSettings.ajax_url, {
         _ajax_nonce: evSettings.nonce,
         action: "update_videos_handler",
         host_id: hostId,
         author_id: authorId,
-        dataType:'html'
-      }, function(data){
+        dataType: 'html'
+      }, function (data) {
         $(feedback).html(data);
         $(spinner).removeClass("is-active");
         fadeNotice(feedback);
@@ -165,33 +192,33 @@
   // AJAX loaded elements must click bind to document
   // http://stackoverflow.com/questions/16598213/how-to-bind-events-on-ajax-loaded-content
   // needs to refresh ev_edit_author table for appropriate host, also
-  var deleteAuthor = function(){
-    $(document).on("click", ".host-authors-list .delete-author", function(e){
+  var deleteAuthor = function () {
+    $(document).on("click", ".host-authors-list .delete-author", function (e) {
 
       e.preventDefault();
 
       var hostId = $(this).attr("data-host"),
-          authorId = $(this).attr("data-author"),
-          form = $(this).parents("form"),
-          list = $(form).parents(".host-authors-list"),
-          feedback = $(list).siblings(".feedback");
-          host = $(form).parents(".ev_edit_authors_host").data("host");
+        authorId = $(this).attr("data-author"),
+        form = $(this).parents("form"),
+        list = $(form).parents(".host-authors-list"),
+        feedback = $(list).siblings(".feedback");
+      host = $(form).parents(".ev_edit_authors_host").data("host");
 
-      if (!confirm('Are you sure you want to delete channel ' + authorId + ' on ' + hostId + '?')){
+      if (!confirm('Are you sure you want to delete channel ' + authorId + ' on ' + hostId + '?')) {
         return false;
       }
 
-      $.post( evSettings.ajax_url, {
+      $.post(evSettings.ajax_url, {
         _ajax_nonce: evSettings.nonce,
         host_id: hostId,
         author_id: authorId,
-        dataType:'html',
+        dataType: 'html',
         action: "delete_author_handler"
-      }, function(data){
+      }, function (data) {
         var message = data;
         $(form).fadeOut(); //first fade out this author
-        refreshSettingsAuthorList(feedback,message); //rebuild the author list from the database
-        refreshHostAuthorList(feedback,list,host,message); //rebuild the host authors list from the database
+        refreshSettingsAuthorList(feedback, message); //rebuild the author list from the database
+        refreshHostAuthorList(feedback, list, host, message); //rebuild the host authors list from the database
         $(feedback).html(message);
         fadeNotice(feedback);
       });
@@ -201,16 +228,16 @@
   // addAuthor needs to refresh ev_edit_author table for appropriate host
   // also needs a varation editAuthor to update db via add_author_handler cb
   // that is bound on document click bc the form is AJAX printed
-  var addAuthor = function(){
-    $(document).on("submit", ".ev_add_author", function(e){
+  var addAuthor = function () {
+    $(document).on("submit", ".ev_add_author", function (e) {
       e.preventDefault();
       var form = $(this);
       authorAjax(form);
     });
   };
 
-  var editAuthor = function(){
-    $(document).on("submit", ".ev_edit_author", function(e){
+  var editAuthor = function () {
+    $(document).on("submit", ".ev_edit_author", function (e) {
       e.preventDefault();
       // $(this).css({backgroundColor: "blue"});
       var form = $(this);
@@ -220,27 +247,27 @@
     });
   };
 
-  var authorAjax = function(form){
+  var authorAjax = function (form) {
     var author = $(form).serialize(),
-        list = $(form).parents(".host-authors-list"),
-        feedback = $(list).siblings(".feedback");
-        host = $(form).parents(".ev_edit_authors_host").data("host");
+      list = $(form).parents(".host-authors-list"),
+      feedback = $(list).siblings(".feedback");
+    host = $(form).parents(".ev_edit_authors_host").data("host");
 
-        // set = JSON.stringify(author, null, 4);
-        // alert(set);
+    // set = JSON.stringify(author, null, 4);
+    // alert(set);
 
-    $.post( evSettings.ajax_url, {
+    $.post(evSettings.ajax_url, {
       _ajax_nonce: evSettings.nonce,
       data: author,
-      dataType:'json',
+      dataType: 'json',
       action: "add_author_handler"
-    }, function(data){
+    }, function (data) {
       // set = JSON.stringify(data, null, 4);
       // alert(set);
       var message = data;
       // $(feedback).html(message);
-      refreshSettingsAuthorList(feedback,message); //rebuild the author list from the database
-      refreshHostAuthorList(feedback,list,host,message); //rebuild the host authors list from the database
+      refreshSettingsAuthorList(feedback, message); //rebuild the author list from the database
+      refreshHostAuthorList(feedback, list, host, message); //rebuild the host authors list from the database
       // fadeNotice(feedback);
     });
   }
@@ -248,12 +275,12 @@
   // Settings Author List refresher
   // Note that ajax loading of html f's up event binding on all loaded elements
   // events herein must be bound to document henceforth
-  var refreshSettingsAuthorList = function(feedback,message){
-    $.get( evSettings.ajax_url, {
+  var refreshSettingsAuthorList = function (feedback, message) {
+    $.get(evSettings.ajax_url, {
       _ajax_nonce: evSettings.nonce,
       action: "author_list_handler",
-      dataType:'html'
-    }, function(data){
+      dataType: 'html'
+    }, function (data) {
       $("#ev_author_list").html(data);
       $(feedback).html(message);
       fadeNotice(feedback);
@@ -263,13 +290,13 @@
   // Host Author List refresher
   // Note that ajax loading of html f's up event binding on all loaded elements
   // events herein must be bound to document henceforth
-  var refreshHostAuthorList = function(feedback,list,host,message){
-    $.post( evSettings.ajax_url, {
+  var refreshHostAuthorList = function (feedback, list, host, message) {
+    $.post(evSettings.ajax_url, {
       _ajax_nonce: evSettings.nonce,
       action: "author_host_list_handler",
       dataType: 'html',
       data: { host_id: host }
-    }, function(data){
+    }, function (data) {
       // set = JSON.stringify(data, null, 4);
       // alert(set);
       $(list).html(data);
@@ -278,26 +305,27 @@
     });
   };
 
-  var generateAllHostAuthorLists = function(){
+  var generateAllHostAuthorLists = function () {
     var hostAuthorLists = $(".ev_edit_authors_host");
     // listlist = JSON.stringify(hostAuthorLists, null, 4);
     // alert(listlist);
 
-    $(hostAuthorLists).each(function(){
+    $(hostAuthorLists).each(function () {
       var feedback = $(this).children(".feedback"),
-          list = $(this).children(".host-authors-list"),
-          host = $(this).data("host"),
-          message = '';
+        list = $(this).children(".host-authors-list"),
+        host = $(this).data("host"),
+        message = '';
       // $(feedback).css({backgroundColor: "red"});
-      refreshHostAuthorList(feedback,list,host,message);
+      refreshHostAuthorList(feedback, list, host, message);
     });
   };
 
-  $(document).ready( function() {
+  $(document).ready(function () {
     tabChange();
     formExpand();
     settingsUpdate();
     updateVideos();
+    unembedVideos();
     checkVideos();
     deleteAll();
     refreshSettingsAuthorList();
@@ -307,4 +335,4 @@
     deleteAuthor();
   });
 
-})( jQuery );
+})(jQuery);

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Automatically syncs your videos from YouTube, Vimeo, Dotsub, Wistia or Dailymoti
 - Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 - Requires at least: 4.4
 - Tested up to: 6.2.2
-- Stable Tag: 1.3.1
+- Stable Tag: 1.3.2
 - License: GPLv2
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 
 
 # Changelog
+
+### 1.3.2
+* New developer option to *remove* embedded videos from `post_content`. (See notes for 1.3.1)
 
 ### 1.3.1
 * New option to *not* automatically embed the video in `post_content` when fetching from the service. The video URL is already stored in `post_meta`. This allows developers to manually add the video elsewhere in the template markup.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.gingertech.net/
 Tags: video, crosspost, sync, YouTube, Vimeo, DotSub, Wistia, Dailymotion
 Requires at least: 4.4
 Tested up to: 6.2.2
-Stable Tag: 1.3.1
+Stable Tag: 1.3.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 7. Media Uploader: inserting External Videos into any page or post
 
 == Changelog ==
+
+= 1.3.2 =
+* New developer option to *remove* embedded videos from `post_content`. (See notes for 1.3.1)
 
 = 1.3.1 =
 * New option to *not* automatically embed the video in `post_content` when fetching from the service. The video URL is already stored in `post_meta`. This allows developers to manually add the video elsewhere in the template markup.


### PR DESCRIPTION
This follows from the last release. 

Someone who has selected the new option *not* to have the embeds automatically added to `post_content` may still have hundreds of existing posts with the embeds. (I know someone like that 😉) This PR adds a utility to the settings page that removes all those embeds from existing `post_content` using a regex. 

It only removes embeds that are at the beginning of the string. If we get a request to search through other paragraphs (e.g. for posts that were manually edited), it's easy enough to do. But as is, it should handle all auto generated posts. 