### PR TITLE
2.0.1 Fix bug in `trash_deleted_videos`, remove Dotsub tab

### DIFF
--- a/core/ev-settings-forms.php
+++ b/core/ev-settings-forms.php
@@ -89,19 +89,19 @@ $HOSTS = $options['hosts'];
               <fieldset>
                 <label for="ev-embed">
                   <input type="checkbox" id="ev-embed" name="ev-embed" value="embed" <?php if ( $ev_embed == true ) echo "checked"; ?>/>
-                  <span><?php esc_attr_e('Embed video in external-video post content? (This is the default. Only disable this if you are writing a custom theme.)', 'external-videos'); ?></span>
+                  <span><?php esc_attr_e('Embed video in external-video post content. (This is the default. Only disable this if you are writing a custom theme.)', 'external-videos'); ?></span>
                 </label>
               </fieldset>
               <fieldset>
                 <label for="ev-title_sync">
                   <input type="checkbox" id="ev-title_sync" name="ev-title_sync" value="title_sync" <?php if ( $ev_title_sync == true ) echo "checked"; ?>/>
-                  <span><?php esc_attr_e('Keep video titles in sync with titles on host (overwrite local edits)?', 'external-videos'); ?></span>
+                  <span><?php esc_attr_e('Keep video titles in sync with titles on host (overwrite local edits)', 'external-videos'); ?></span>
                 </label>
               </fieldset>
               <fieldset>
                 <label for="ev-content_sync">
                   <input type="checkbox" id="ev-content_sync" name="ev-content_sync" value="content_sync" <?php if ( $ev_content_sync == true ) echo "checked"; ?>/>
-                  <span><?php esc_attr_e('Keep video descriptions in sync with descriptions on host (overwrite local edits)?', 'external-videos'); ?></span>
+                  <span><?php esc_attr_e('Keep video descriptions in sync with descriptions on host (overwrite local edits)', 'external-videos'); ?></span>
                 </label>
               </fieldset>
               <fieldset>

--- a/core/ev-sync-posts.php
+++ b/core/ev-sync-posts.php
@@ -850,27 +850,29 @@ class SP_EV_SyncPosts {
                                  $current_video_ids ) {
 
     // we're going to count how many were deleted at each host
-    // must fill out this array with zeros, or error
+    // must fill out $count_deleted[$host_id] with zeros, or error
     $count_deleted = array();
 
+    // there will only be one update_host in the event of a selected author
     foreach( $update_hosts as $host ){
       $host_id = $host['host_id'];
       $count_deleted[$host_id] = 0;
     }
 
+    // no selected update_author means get all hosts all authors
     if( $update_author == null ){
 
       $existing_videos = $this->get_video_posts();
 
     } else {
 
-      $host_id = $update_hosts[0]['host_id'];
+      // $host_id already defined above
       $author_id = $update_author['author_id'];
-
       $existing_videos = $this->get_video_posts( $host_id, $author_id );
+
     }
 
-    // error_log( print_r( $current_video_ids, true ) );
+    // error_log( '$current_video_ids: ' . print_r( $current_video_ids, true ) );
 
     // Check this is working. Value could be an array
     while( $existing_videos->have_posts() ) {

--- a/external-videos.php
+++ b/external-videos.php
@@ -4,7 +4,7 @@
 * Plugin URI: http://wordpress.org/extend/plugins/external-videos/
 * Description: Automatically syncs your videos from YouTube, Vimeo, Wistia or Dailymotion to your WordPress site as new posts.
 * Author: Silvia Pfeiffer and Andrew Nimmo
-* Version: 2.0.0
+* Version: 2.0.1
 * Author URI: http://www.gingertech.net/
 * License: GPL2
 * Text Domain: external-videos

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Automatically syncs your videos from YouTube, Vimeo, Wistia or Dailymotion to yo
 - Tags: video, crosspost, sync, YouTube, Vimeo, Wistia, Dailymotion
 - Requires at least: 4.4
 - Tested up to: 6.2.2
-- Stable Tag: 2.0.0
+- Stable Tag: 2.0.1
 - License: GPLv2
 - License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 
 
 # Changelog
+
+### 2.0.1
+* Bug fix for SP_EV_SyncPosts::trash_deleted_videos
 
 ### 2.0.0
 * Refactor of post syncing code

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.gingertech.net/
 Tags: video, crosspost, sync, YouTube, Vimeo, Wistia, Dailymotion
 Requires at least: 4.4
 Tested up to: 6.2.2
-Stable Tag: 2.0.0
+Stable Tag: 2.0.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -85,6 +85,9 @@ Yes, you can pick any slug you like in Settings->External Videos, as long as it 
 7. Media Uploader: inserting External Videos into any page or post
 
 == Changelog ==
+
+= 2.0.1 =
+* Bug fix for SP_EV_SyncPosts::trash_deleted_videos
 
 = 2.0.0 =
 * Refactor of post syncing code


### PR DESCRIPTION
There was a bug in counting the existing videos against the host ID's that caused valid videos to be moved to the trash, and then restored. This fixes the bug.

Also deletes the Dotsub tab from the Settings page.